### PR TITLE
Added preload:none

### DIFF
--- a/app/views/audiobooks/show.html.erb
+++ b/app/views/audiobooks/show.html.erb
@@ -15,7 +15,7 @@
   <% @current.audios.each do |audio| %>
     <li>
       <h3><%= audio.name %></h3>
-      <%= audio_tag stream_path(path: audio.path), controls: true %>
+      <%= audio_tag stream_path(path: audio.path), controls: true, preload: :none %>
       </audio>
     </li>
   <% end %>


### PR DESCRIPTION
Prevent browser preloading which puts a strain on the page when several audiobooks are on it.